### PR TITLE
Corrected reading a short int with %hd instead of %d

### DIFF
--- a/amr15a.c
+++ b/amr15a.c
@@ -2,10 +2,10 @@
 int main()
 {
     short N, a, lucky = 0;
-    scanf("%d", &N);
+    scanf("%hd", &N);
     while(N--)
         {
-            scanf("%d", &a);
+            scanf("%hd", &a);
             (a%2 == 0)?(lucky++):(lucky--);
         }
     (lucky > 0)?(printf("READY FOR BATTLE")):(printf("NOT READY"));


### PR DESCRIPTION
Fixed an error where an int was read instad of a short int, which could overwrite a variable in use. In my case with GCC the variable N was overwritten when the variable a was read with scanf.